### PR TITLE
Feature/countnew

### DIFF
--- a/gcexport.py
+++ b/gcexport.py
@@ -450,7 +450,7 @@ def parse_arguments(argv):
     parser.add_argument('--password',
         help='your Garmin Connect password (otherwise, you will be prompted)')
     parser.add_argument('-c', '--count', default='1',
-        help='number of recent activities to download, or \'all\' or \'new\' (default: 1)'
+        help="number of recent activities to download, or 'all' or 'new' (default: 1). "
                         "'new' or 'number' downloads the latest activities by activity's date/time")
     parser.add_argument('-e', '--external',
         help='path to external program to pass CSV file too')
@@ -474,7 +474,7 @@ def parse_arguments(argv):
     parser.add_argument('-fp', '--fileprefix', action='count', default=0,
         help="set the local time as activity file name prefix")
     parser.add_argument('-sa', '--start_activity_no', type=int, default=1,
-        help="set index to skip the newest activities. E.g. 3 will not download the last 2 ones")
+        help="set index for the newest activity to download, starting with '1'. E.g. 3 will not download the last 2 ones")
 
     return parser.parse_args(argv[1:])
 
@@ -960,7 +960,7 @@ def main(argv):
         if len(activities) != num_to_download:
             logging.warning('Expected %s activities, got %s.', num_to_download, len(activities))
 
-        # Process each activity; start with the oldest one. Running from oldest to newest is necessary to save the
+        # Processing each activity; starting with the oldest one. Running from oldest to newest is necessary to save the
         # oldest successful downloaded activity. Doing it so, 'count new' has a starting point to fetch the latest ones
         # at the next time.
         for actvty in activities[::-1]:

--- a/gcexport.py
+++ b/gcexport.py
@@ -450,8 +450,11 @@ def parse_arguments(argv):
     parser.add_argument('--password',
         help='your Garmin Connect password (otherwise, you will be prompted)')
     parser.add_argument('-c', '--count', default='1',
-        help="number of recent activities to download, or 'all' or 'new' (default: 1). "
-                        "'new' or 'number' downloads the latest activities by activity's date/time")
+                        help="number of recent activities to download, or 'all' or 'new' (default: 1). "
+                             "'all' will always download all activities. "
+                             "'number' downloads the latest 'COUNT' activities. "
+                             "'new' downloads the latest not yet downloaded activities (by index, so Garmin Connect's "
+                             "activity list may not have been changed).")
     parser.add_argument('-e', '--external',
         help='path to external program to pass CSV file too')
     parser.add_argument('-a', '--args',
@@ -474,7 +477,8 @@ def parse_arguments(argv):
     parser.add_argument('-fp', '--fileprefix', action='count', default=0,
         help="set the local time as activity file name prefix")
     parser.add_argument('-sa', '--start_activity_no', type=int, default=1,
-        help="set index for the newest activity to download, starting with '1'. E.g. 3 will not download the last 2 ones")
+                        help="set index for the newest activity to download, starting with '1'. E.g. 3 will not "
+                             "download the last 2 ones")
 
     return parser.parse_args(argv[1:])
 
@@ -960,7 +964,7 @@ def main(argv):
         if len(activities) != num_to_download:
             logging.warning('Expected %s activities, got %s.', num_to_download, len(activities))
 
-        # Processing each activity; starting with the oldest one. Running from oldest to newest is necessary to save the
+        # Process each activity, start with the oldest one. Running from oldest to newest is necessary to save the
         # newest successful downloaded activity. Doing it so, 'count new' has a starting point to fetch the latest ones
         # at the next time.
         for actvty in activities[::-1]:

--- a/gcexport.py
+++ b/gcexport.py
@@ -961,7 +961,7 @@ def main(argv):
             logging.warning('Expected %s activities, got %s.', num_to_download, len(activities))
 
         # Processing each activity; starting with the oldest one. Running from oldest to newest is necessary to save the
-        # oldest successful downloaded activity. Doing it so, 'count new' has a starting point to fetch the latest ones
+        # newest successful downloaded activity. Doing it so, 'count new' has a starting point to fetch the latest ones
         # at the next time.
         for actvty in activities[::-1]:
 

--- a/gcexport_test.py
+++ b/gcexport_test.py
@@ -4,6 +4,7 @@ Tests for gcexport.py; Call them with this command line:
 
 py.test gcexport_test.py
 """
+import shutil
 
 from gcexport import *
 try:
@@ -126,3 +127,37 @@ def test_resolve_path():
     assert resolve_path('root', 'sub/{yyyy}', '2018-03-08 12:23:22') == 'root/sub/{yyyy}'
     assert resolve_path('root', 'sub/{YYYYMM}', '2018-03-08 12:23:22') == 'root/sub/{YYYYMM}'
     assert resolve_path('root', 'sub/all', '2018-03-08 12:23:22') == 'root/sub/all'
+
+
+def test_read_settings():
+    test_dir = ".unittestdir"
+
+    # Setup
+    if os.path.exists(test_dir):
+        shutil.rmtree(test_dir)
+
+    os.mkdir(test_dir)
+
+    #  Test initial state
+    act_pickle = read_settings(test_dir)
+    exp_pickle = dict(activity_indices=dict(gpx=0, json=0, original=0,tcx=0))
+
+    assert act_pickle == exp_pickle
+
+    # Test updates
+    write_last_activity_index(test_dir, 1, 'gpx')
+    write_last_activity_index(test_dir, 22, 'json')
+    write_last_activity_index(test_dir, 333, 'original')
+    write_last_activity_index(test_dir, 4444, 'tcx')
+
+    act_pickle = read_settings(test_dir)
+
+    exp_pickle['activity_indices']['gpx'] = 1
+    exp_pickle['activity_indices']['json'] = 22
+    exp_pickle['activity_indices']['original'] = 333
+    exp_pickle['activity_indices']['tcx'] = 4444
+
+    assert act_pickle == exp_pickle
+
+    # Tear down
+    shutil.rmtree(test_dir)


### PR DESCRIPTION
Added argument 'count new'. This will download all new activities. For this, a pickle file '.settings' in the download directory will be used. It holds the index of the newest/latest activity that is downloaded successfully. The file will be updated every time an newer activity is downloaded (independent of the arguments).
'Count new ' is using the total activity index. This will fail, if activities will be deleted or inserted on Garmin Connect.
To achieve a seamless and stable download history, the download order is now inverted - from oldest to newest. This does not quite fit with the known behavior and in special with the -sa argument. But from my point of view it is the better way. Parameter start_activity_no is still proper working but now a little bit hard to understand :0|

Examples:
// User has 5 activities on Garmin Connect with index 1 (oldest) .. index 5 (newest)
gcexport count 3          // Fetch  activities by index 3-5, save '5' in .settings
// User creates new activity with index 6 on Garmin Connect
gcexport count new      // Fetch activity with index 6 and update .settings with '6'
gcexport count new     // No effect
gcexport count 5 -sa 4 // Fetch activity index 1, .settings will be untouched
rm download/.setting
gcexport count new      // Fetch activities with index 1..6 and update .settings with '6'
// User deletes activity with index 3 and creates new activity on Garmin Connect. This new activity will have index 6.
gcexport count new     // No effect - total number of activities hasn't changed and the last index is still '6'  :0(
