### PR TITLE
Updated to skip activities where the activity download page is non-existent and zip archive function 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ optional arguments:
   -sa START_ACTIVITY_NO, --start_activity_no START_ACTIVITY_NO
                         give index for first activity to import, i.e. skipping
                         the newest activites
+  -af, --archive DIRECTORY/Filename.zip
+                        Append newly downloaded activity files to the archive
+                        .zip file.                       
 ```
 
 Examples:


### PR DESCRIPTION
I have fixed the activity download abend that occured when an activity download page did not exist. I have also added a new option that automatically creates a zip file from the downloaded activities.

The archive operates as

if an archive exists, unzip all files to a temp folder
copy all downloaded activities into the temp folder. This will update any existing changed activities.
replace the zipfile with all the activities in the temp folder 