### PR TITLE
Archive (zip) option also found and corrected an HTTP 404 error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ optional arguments:
   -sa START_ACTIVITY_NO, --start_activity_no START_ACTIVITY_NO
                         give index for first activity to import, i.e. skipping
                         the newest activites
+  -af, --archive DIRECTORY/Filename.zip
+                        Append newly downloaded activity files to the archive
+                        .zip file.                       
 ```
 
 Examples:


### PR DESCRIPTION
1) Fixed a 404 error caused when an activity listed does not exist

2) added a --archive option to create and merge downloaded activity files into a zip file.
after new activities are downloaded the zip file is expanded, new activities added so no duplicates exist, and then files are re-zipped.