### PR TITLE
New feature 'exclude-filter'

### DIFF
--- a/filtering.py
+++ b/filtering.py
@@ -1,0 +1,78 @@
+import logging
+import sys
+
+from os import path
+import json
+
+DOWNLOADED_IDS_FILE_NAME = "downloaded_ids.json"
+KEY_IDS = "ids"
+
+
+def read_exclude(file):
+    """
+    Returns list with ids from json file. Errors will be printed
+    :param file: String with file path to exclude
+    :return: List with IDs or, if file not found, None.
+    """
+
+    if not path.exists(file):
+        print("File not found: " + file)
+        return None
+
+    if not path.isfile(file):
+        print("Not a file: " + file)
+        return None
+
+    with open(file, 'r') as f:
+
+        try:
+            obj = json.load(f)
+            return obj['ids']
+
+        # except JSONDecodeError: only in Python3, use the more generic type instead
+        except ValueError:
+            print("No valid json in: " + file)
+            return None
+
+
+def update_download_stats(activity_id, dir):
+    """
+    Add item to download_stats file, if not already there. Call this for every successful downloaded activity.
+    The statistic is independent of the downloaded file type.
+    :param activity_id: String with activity ID
+    :param dir: Download root directory
+    """
+    file = path.join(dir, DOWNLOADED_IDS_FILE_NAME)
+
+    # Very first time: touch the file
+    if not path.exists(file):
+        with open(file, 'w') as read_obj:
+            read_obj.write(json.dumps(""))
+
+    # read file
+    with open(file, 'r') as read_obj:
+        data = read_obj.read()
+
+        try:
+            obj = json.loads(data)
+
+        # except JSONDecodeError: only in Python3, use the more generic type instead
+        except ValueError:
+            obj = ""
+
+    # Sanitize wrong formats
+    if not type(obj) is dict:
+        obj = dict()
+
+    if KEY_IDS not in obj:
+        obj[KEY_IDS] = []
+
+    if activity_id in obj[KEY_IDS]:
+        logging.info("%s already in %s", activity_id, file)
+        return
+
+    obj[KEY_IDS].append(activity_id)
+    obj[KEY_IDS].sort()
+
+    with open(file, 'w') as write_obj:
+        write_obj.write(json.dumps(obj))

--- a/filtering_test.py
+++ b/filtering_test.py
@@ -1,0 +1,119 @@
+import unittest
+import filtering
+import tempfile
+from os import path
+from os import remove
+from filtering import DOWNLOADED_IDS_FILE_NAME
+from filtering import KEY_IDS
+import json
+
+DIR = tempfile.gettempdir()
+
+
+class TestExcludeFile(unittest.TestCase):
+
+    @property
+    def file_under_test(self):
+        return path.join(DIR, "exclude.json")
+
+    @property
+    def non_existing_file(self):
+        return path.join(DIR, "non_existing_exclude.json")
+
+    @property
+    def dir(self):
+        return DIR
+
+    def setUp(self):
+        if path.exists(self.file_under_test):
+            remove(self.file_under_test)
+
+        if path.exists(self.non_existing_file):
+            remove(self.non_existing_file)
+
+    def test_read_exclude(self):
+        self.assertIsNone(filtering.read_exclude(self.non_existing_file))
+
+        with open(self.file_under_test, 'w') as f:
+            json.dump(dict(ids=["1001", "1002", "1010", "1003"]), f)
+
+        ids = filtering.read_exclude(self.file_under_test)
+
+        self.assertEqual(len(ids), 4)
+
+        self.assertIn("1001", ids)
+        self.assertIn("1002", ids)
+        self.assertIn("1003", ids)
+        self.assertIn("1010", ids)
+
+
+class TestDownloadStats(unittest.TestCase):
+
+    @property
+    def file_under_test(self):
+        return path.join(DIR, DOWNLOADED_IDS_FILE_NAME)
+
+    @property
+    def dir(self):
+        return DIR
+
+    def setUp(self):
+        if path.exists(self.file_under_test):
+            remove(self.file_under_test)
+
+    def test_new_file(self):
+        filtering.update_download_stats('1000', self.dir)
+
+        with open(self.file_under_test, 'r') as actual_file:
+            actual = json.load(actual_file)
+
+            self.assertEqual(actual[KEY_IDS][0], '1000')
+
+    def test_1000_items(self):
+
+        r = range(1, 1000)
+
+        for i in r:
+            filtering.update_download_stats(str(i), self.dir)
+
+        with open(self.file_under_test, 'r') as actual_file:
+            actual = json.load(actual_file)
+
+            self.assertEqual(len(actual[KEY_IDS]), len(r))
+
+    def test_new_item(self):
+        filtering.update_download_stats('1000', self.dir)
+        filtering.update_download_stats('1010', self.dir)
+
+        with open(self.file_under_test, 'r') as actual_file:
+            actual = json.load(actual_file)
+
+            self.assertEqual(actual[KEY_IDS][0], '1000')
+            self.assertEqual(actual[KEY_IDS][1], '1010')
+
+    def test_corrupted_file(self):
+        with open(self.file_under_test, 'w') as corrupted_file:
+            corrupted_file.write("HUGO")
+
+        filtering.update_download_stats('1000', self.dir)
+
+        with open(self.file_under_test, 'r') as actual_file:
+            actual = json.load(actual_file)
+
+            self.assertEqual(actual[KEY_IDS][0], '1000')
+
+    def test_sort(self):
+        filtering.update_download_stats('1010', self.dir)
+        filtering.update_download_stats('1000', self.dir)
+        filtering.update_download_stats('1005', self.dir)
+
+        with open(self.file_under_test, 'r') as actual_file:
+            actual = json.load(actual_file)
+
+            self.assertEqual(actual[KEY_IDS][0], '1000')
+            self.assertEqual(actual[KEY_IDS][1], '1005')
+            self.assertEqual(actual[KEY_IDS][2], '1010')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gcexport.py
+++ b/gcexport.py
@@ -41,7 +41,6 @@ import string
 import sys
 import unicodedata
 import zipfile
-
 from filtering import update_download_stats, read_exclude
 
 python3 = sys.version_info.major == 3
@@ -55,7 +54,8 @@ if python3:
     from urllib.request import Request, HTTPError, URLError
 
     COOKIE_JAR = http.cookiejar.CookieJar()
-    OPENER = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(COOKIE_JAR), urllib.request.HTTPSHandler(debuglevel=0))
+    OPENER = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(COOKIE_JAR),
+                                         urllib.request.HTTPSHandler(debuglevel=0))
 else:
     import cookielib
     import urllib2
@@ -447,54 +447,37 @@ def parse_arguments(argv):
 
     parser.add_argument('--version', action='version', version='%(prog)s ' + SCRIPT_VERSION,
                         help='print version and exit')
-
     parser.add_argument('-v', '--verbosity', action='count', default=0,
                         help='increase output verbosity')
-
     parser.add_argument('--username',
                         help='your Garmin Connect username or email address (otherwise, you will be prompted)')
-
     parser.add_argument('--password',
                         help='your Garmin Connect password (otherwise, you will be prompted)')
-
     parser.add_argument('-c', '--count', default='1',
                         help='number of recent activities to download, or \'all\' (default: 1)')
-
     parser.add_argument('-e', '--external',
                         help='path to external program to pass CSV file too')
-
     parser.add_argument('-a', '--args',
                         help='additional arguments to pass to external program')
-
     parser.add_argument('-f', '--format', choices=['gpx', 'tcx', 'original', 'json'], default='gpx',
                         help="export format; can be 'gpx', 'tcx', 'original' or 'json' (default: 'gpx')")
-
     parser.add_argument('-d', '--directory', default=activities_directory,
                         help='the directory to export to (default: \'./YYYY-MM-DD_garmin_connect_export\')')
-
     parser.add_argument('-s', "--subdir",
-                        help="the subdirectory for activity files (tcx, gpx etc.), supported placeholders are {YYYY} "
-                             "and {MM} (default: export directory)")
-
+                        help="the subdirectory for activity files (tcx, gpx etc.), supported placeholders are {YYYY} and {MM}"
+                             " (default: export directory)")
     parser.add_argument('-u', '--unzip', action='store_true',
                         help='if downloading ZIP files (format: \'original\'), unzip the file and remove the ZIP file')
-
     parser.add_argument('-ot', '--originaltime', action='store_true',
                         help='will set downloaded (and possibly unzipped) file time to the activity start time')
-
     parser.add_argument('--desc', type=int, nargs='?', const=0, default=None,
-                        help='append the activity\'s description to the file name of the download; limit size if '
-                             'number is given')
-
+                        help='append the activity\'s description to the file name of the download; limit size if number is given')
     parser.add_argument('-t', '--template', default=CSV_TEMPLATE,
                         help='template file with desired columns for CSV output')
-
     parser.add_argument('-fp', '--fileprefix', action='count', default=0,
                         help="set the local time as activity file name prefix")
-
     parser.add_argument('-sa', '--start_activity_no', type=int, default=1,
-                        help="give index for first activity to import, i.e. skipping the newest activities. "
-                             "Default is '1'.")
+                        help="give index for first activity to import, i.e. skipping the newest activites. Default is '1'.")
 
     parser.add_argument('-ex', '--exclude', metavar="FILE",
                         help="Json file with Array of activity IDs to exclude from download. "

--- a/gcexport.py
+++ b/gcexport.py
@@ -41,7 +41,6 @@ import string
 import sys
 import unicodedata
 import zipfile
-
 from filtering import update_download_stats, read_exclude
 
 python3 = sys.version_info.major == 3
@@ -55,8 +54,7 @@ if python3:
     from urllib.request import Request, HTTPError, URLError
 
     COOKIE_JAR = http.cookiejar.CookieJar()
-    OPENER = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(COOKIE_JAR),
-                                         urllib.request.HTTPSHandler(debuglevel=0))
+    OPENER = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(COOKIE_JAR), urllib.request.HTTPSHandler(debuglevel=0))
 else:
     import cookielib
     import urllib2
@@ -478,7 +476,7 @@ def parse_arguments(argv):
     parser.add_argument('-fp', '--fileprefix', action='count', default=0,
                         help="set the local time as activity file name prefix")
     parser.add_argument('-sa', '--start_activity_no', type=int, default=1,
-                        help="give index for first activity to import, i.e. skipping the newest activites. Default is '1'.")
+                        help="give index for first activity to import, i.e. skipping the newest activities. Default is '1'.")
 
     parser.add_argument('-ex', '--exclude', metavar="FILE",
                         help="Json file with Array of activity IDs to exclude from download. "
@@ -568,160 +566,71 @@ def csv_write_record(csv_filter, extract, actvty, details, activity_type_name, e
     csv_filter.set_column('description', actvty['description'] if present('description', actvty) else None)
     csv_filter.set_column('startTimeIso', extract['start_time_with_offset'].isoformat())
     csv_filter.set_column('startTime1123', extract['start_time_with_offset'].strftime(ALMOST_RFC_1123))
-    csv_filter.set_column('startTimeMillis',
-                          str(actvty['beginTimestamp']) if present('beginTimestamp', actvty) else None)
-    csv_filter.set_column('startTimeRaw', details['summaryDTO']['startTimeLocal'] if present('startTimeLocal', details[
-        'summaryDTO']) else None)
-    csv_filter.set_column('endTimeIso',
-                          extract['end_time_with_offset'].isoformat() if extract['end_time_with_offset'] else None)
-    csv_filter.set_column('endTime1123', extract['end_time_with_offset'].strftime(ALMOST_RFC_1123) if extract[
-        'end_time_with_offset'] else None)
-    csv_filter.set_column('endTimeMillis',
-                          str(actvty['beginTimestamp'] + extract['elapsed_seconds'] * 1000) if present('beginTimestamp',
-                                                                                                       actvty) else None)
+    csv_filter.set_column('startTimeMillis', str(actvty['beginTimestamp']) if present('beginTimestamp', actvty) else None)
+    csv_filter.set_column('startTimeRaw', details['summaryDTO']['startTimeLocal'] if present('startTimeLocal', details['summaryDTO']) else None)
+    csv_filter.set_column('endTimeIso', extract['end_time_with_offset'].isoformat() if extract['end_time_with_offset'] else None)
+    csv_filter.set_column('endTime1123', extract['end_time_with_offset'].strftime(ALMOST_RFC_1123) if extract['end_time_with_offset'] else None)
+    csv_filter.set_column('endTimeMillis', str(actvty['beginTimestamp'] + extract['elapsed_seconds'] * 1000) if present('beginTimestamp', actvty) else None)
     csv_filter.set_column('durationRaw', str(round(actvty['duration'], 3)) if present('duration', actvty) else None)
-    csv_filter.set_column('duration',
-                          hhmmss_from_seconds(round(actvty['duration'])) if present('duration', actvty) else None)
-    csv_filter.set_column('elapsedDurationRaw',
-                          str(round(extract['elapsed_duration'], 3)) if extract['elapsed_duration'] else None)
-    csv_filter.set_column('elapsedDuration', hhmmss_from_seconds(round(extract['elapsed_duration'])) if extract[
-        'elapsed_duration'] else None)
-    csv_filter.set_column('movingDurationRaw',
-                          str(round(details['summaryDTO']['movingDuration'], 3)) if present('movingDuration', details[
-                              'summaryDTO']) else None)
-    csv_filter.set_column('movingDuration',
-                          hhmmss_from_seconds(round(details['summaryDTO']['movingDuration'])) if present(
-                              'movingDuration', details['summaryDTO']) else None)
-    csv_filter.set_column('distanceRaw',
-                          "{0:.5f}".format(actvty['distance'] / 1000) if present('distance', actvty) else None)
-    csv_filter.set_column('averageSpeedRaw',
-                          kmh_from_mps(details['summaryDTO']['averageSpeed']) if present('averageSpeed', details[
-                              'summaryDTO']) else None)
-    csv_filter.set_column('averageSpeedPaceRaw',
-                          trunc6(pace_or_speed_raw(type_id, parent_type_id, actvty['averageSpeed'])) if present(
-                              'averageSpeed', actvty) else None)
-    csv_filter.set_column('averageSpeedPace',
-                          pace_or_speed_formatted(type_id, parent_type_id, actvty['averageSpeed']) if present(
-                              'averageSpeed', actvty) else None)
-    csv_filter.set_column('averageMovingSpeedRaw',
-                          kmh_from_mps(details['summaryDTO']['averageMovingSpeed']) if present('averageMovingSpeed',
-                                                                                               details[
-                                                                                                   'summaryDTO']) else None)
-    csv_filter.set_column('averageMovingSpeedPaceRaw', trunc6(
-        pace_or_speed_raw(type_id, parent_type_id, details['summaryDTO']['averageMovingSpeed'])) if present(
-        'averageMovingSpeed', details['summaryDTO']) else None)
-    csv_filter.set_column('averageMovingSpeedPace', pace_or_speed_formatted(type_id, parent_type_id,
-                                                                            details['summaryDTO'][
-                                                                                'averageMovingSpeed']) if present(
-        'averageMovingSpeed', details['summaryDTO']) else None)
-    csv_filter.set_column('maxSpeedRaw', kmh_from_mps(details['summaryDTO']['maxSpeed']) if present('maxSpeed', details[
-        'summaryDTO']) else None)
-    csv_filter.set_column('maxSpeedPaceRaw', trunc6(
-        pace_or_speed_raw(type_id, parent_type_id, details['summaryDTO']['maxSpeed'])) if present('maxSpeed', details[
-        'summaryDTO']) else None)
-    csv_filter.set_column('maxSpeedPace', pace_or_speed_formatted(type_id, parent_type_id,
-                                                                  details['summaryDTO']['maxSpeed']) if present(
-        'maxSpeed', details['summaryDTO']) else None)
-    csv_filter.set_column('elevationLoss',
-                          str(round(details['summaryDTO']['elevationLoss'], 2)) if present('elevationLoss', details[
-                              'summaryDTO']) else None)
-    csv_filter.set_column('elevationLossUncorr', str(round(details['summaryDTO']['elevationLoss'], 2)) if not actvty[
-        'elevationCorrected'] and present('elevationLoss', details['summaryDTO']) else None)
-    csv_filter.set_column('elevationLossCorr', str(round(details['summaryDTO']['elevationLoss'], 2)) if actvty[
-                                                                                                            'elevationCorrected'] and present(
-        'elevationLoss', details['summaryDTO']) else None)
-    csv_filter.set_column('elevationGain',
-                          str(round(details['summaryDTO']['elevationGain'], 2)) if present('elevationGain', details[
-                              'summaryDTO']) else None)
-    csv_filter.set_column('elevationGainUncorr', str(round(details['summaryDTO']['elevationGain'], 2)) if not actvty[
-        'elevationCorrected'] and present('elevationGain', details['summaryDTO']) else None)
-    csv_filter.set_column('elevationGainCorr', str(round(details['summaryDTO']['elevationGain'], 2)) if actvty[
-                                                                                                            'elevationCorrected'] and present(
-        'elevationGain', details['summaryDTO']) else None)
-    csv_filter.set_column('minElevation',
-                          str(round(details['summaryDTO']['minElevation'], 2)) if present('minElevation', details[
-                              'summaryDTO']) else None)
-    csv_filter.set_column('minElevationUncorr', str(round(details['summaryDTO']['minElevation'], 2)) if not actvty[
-        'elevationCorrected'] and present('minElevation', details['summaryDTO']) else None)
-    csv_filter.set_column('minElevationCorr', str(round(details['summaryDTO']['minElevation'], 2)) if actvty[
-                                                                                                          'elevationCorrected'] and present(
-        'minElevation', details['summaryDTO']) else None)
-    csv_filter.set_column('maxElevation',
-                          str(round(details['summaryDTO']['maxElevation'], 2)) if present('maxElevation', details[
-                              'summaryDTO']) else None)
-    csv_filter.set_column('maxElevationUncorr', str(round(details['summaryDTO']['maxElevation'], 2)) if not actvty[
-        'elevationCorrected'] and present('maxElevation', details['summaryDTO']) else None)
-    csv_filter.set_column('maxElevationCorr', str(round(details['summaryDTO']['maxElevation'], 2)) if actvty[
-                                                                                                          'elevationCorrected'] and present(
-        'maxElevation', details['summaryDTO']) else None)
+    csv_filter.set_column('duration', hhmmss_from_seconds(round(actvty['duration'])) if present('duration', actvty) else None)
+    csv_filter.set_column('elapsedDurationRaw', str(round(extract['elapsed_duration'], 3)) if extract['elapsed_duration'] else None)
+    csv_filter.set_column('elapsedDuration', hhmmss_from_seconds(round(extract['elapsed_duration'])) if extract['elapsed_duration'] else None)
+    csv_filter.set_column('movingDurationRaw', str(round(details['summaryDTO']['movingDuration'], 3)) if present('movingDuration', details['summaryDTO']) else None)
+    csv_filter.set_column('movingDuration', hhmmss_from_seconds(round(details['summaryDTO']['movingDuration'])) if present('movingDuration', details['summaryDTO']) else None)
+    csv_filter.set_column('distanceRaw', "{0:.5f}".format(actvty['distance'] / 1000) if present('distance', actvty) else None)
+    csv_filter.set_column('averageSpeedRaw', kmh_from_mps(details['summaryDTO']['averageSpeed']) if present('averageSpeed', details['summaryDTO']) else None)
+    csv_filter.set_column('averageSpeedPaceRaw', trunc6(pace_or_speed_raw(type_id, parent_type_id, actvty['averageSpeed'])) if present('averageSpeed', actvty) else None)
+    csv_filter.set_column('averageSpeedPace', pace_or_speed_formatted(type_id, parent_type_id, actvty['averageSpeed']) if present('averageSpeed', actvty) else None)
+    csv_filter.set_column('averageMovingSpeedRaw', kmh_from_mps(details['summaryDTO']['averageMovingSpeed']) if present('averageMovingSpeed', details['summaryDTO']) else None)
+    csv_filter.set_column('averageMovingSpeedPaceRaw', trunc6(pace_or_speed_raw(type_id, parent_type_id, details['summaryDTO']['averageMovingSpeed'])) if present('averageMovingSpeed', details['summaryDTO']) else None)
+    csv_filter.set_column('averageMovingSpeedPace', pace_or_speed_formatted(type_id, parent_type_id, details['summaryDTO']['averageMovingSpeed']) if present('averageMovingSpeed', details['summaryDTO']) else None)
+    csv_filter.set_column('maxSpeedRaw', kmh_from_mps(details['summaryDTO']['maxSpeed']) if present('maxSpeed', details['summaryDTO']) else None)
+    csv_filter.set_column('maxSpeedPaceRaw', trunc6(pace_or_speed_raw(type_id, parent_type_id, details['summaryDTO']['maxSpeed'])) if present('maxSpeed', details['summaryDTO']) else None)
+    csv_filter.set_column('maxSpeedPace', pace_or_speed_formatted(type_id, parent_type_id, details['summaryDTO']['maxSpeed']) if present('maxSpeed', details['summaryDTO']) else None)
+    csv_filter.set_column('elevationLoss', str(round(details['summaryDTO']['elevationLoss'], 2)) if present('elevationLoss', details['summaryDTO']) else None)
+    csv_filter.set_column('elevationLossUncorr', str(round(details['summaryDTO']['elevationLoss'], 2)) if not actvty['elevationCorrected'] and present('elevationLoss', details['summaryDTO']) else None)
+    csv_filter.set_column('elevationLossCorr', str(round(details['summaryDTO']['elevationLoss'], 2)) if actvty['elevationCorrected'] and present('elevationLoss', details['summaryDTO']) else None)
+    csv_filter.set_column('elevationGain', str(round(details['summaryDTO']['elevationGain'], 2)) if present('elevationGain', details['summaryDTO']) else None)
+    csv_filter.set_column('elevationGainUncorr', str(round(details['summaryDTO']['elevationGain'], 2)) if not actvty['elevationCorrected'] and present('elevationGain', details['summaryDTO']) else None)
+    csv_filter.set_column('elevationGainCorr', str(round(details['summaryDTO']['elevationGain'], 2)) if actvty['elevationCorrected'] and present('elevationGain', details['summaryDTO']) else None)
+    csv_filter.set_column('minElevation', str(round(details['summaryDTO']['minElevation'], 2)) if present('minElevation', details['summaryDTO']) else None)
+    csv_filter.set_column('minElevationUncorr', str(round(details['summaryDTO']['minElevation'], 2)) if not actvty['elevationCorrected'] and present('minElevation', details['summaryDTO']) else None)
+    csv_filter.set_column('minElevationCorr', str(round(details['summaryDTO']['minElevation'], 2)) if actvty['elevationCorrected'] and present('minElevation', details['summaryDTO']) else None)
+    csv_filter.set_column('maxElevation', str(round(details['summaryDTO']['maxElevation'], 2)) if present('maxElevation', details['summaryDTO']) else None)
+    csv_filter.set_column('maxElevationUncorr', str(round(details['summaryDTO']['maxElevation'], 2)) if not actvty['elevationCorrected'] and present('maxElevation', details['summaryDTO']) else None)
+    csv_filter.set_column('maxElevationCorr', str(round(details['summaryDTO']['maxElevation'], 2)) if actvty['elevationCorrected'] and present('maxElevation', details['summaryDTO']) else None)
     csv_filter.set_column('elevationCorrected', 'true' if actvty['elevationCorrected'] else 'false')
     # csv_record += empty_record  # no minimum heart rate in JSON
-    csv_filter.set_column('maxHRRaw',
-                          str(details['summaryDTO']['maxHR']) if present('maxHR', details['summaryDTO']) else None)
+    csv_filter.set_column('maxHRRaw', str(details['summaryDTO']['maxHR']) if present('maxHR', details['summaryDTO']) else None)
     csv_filter.set_column('maxHR', "{0:.0f}".format(actvty['maxHR']) if present('maxHR', actvty) else None)
-    csv_filter.set_column('averageHRRaw', str(details['summaryDTO']['averageHR']) if present('averageHR', details[
-        'summaryDTO']) else None)
+    csv_filter.set_column('averageHRRaw', str(details['summaryDTO']['averageHR']) if present('averageHR', details['summaryDTO']) else None)
     csv_filter.set_column('averageHR', "{0:.0f}".format(actvty['averageHR']) if present('averageHR', actvty) else None)
-    csv_filter.set_column('caloriesRaw', str(details['summaryDTO']['calories']) if present('calories', details[
-        'summaryDTO']) else None)
-    csv_filter.set_column('calories', "{0:.0f}".format(details['summaryDTO']['calories']) if present('calories',
-                                                                                                     details[
-                                                                                                         'summaryDTO']) else None)
+    csv_filter.set_column('caloriesRaw', str(details['summaryDTO']['calories']) if present('calories', details['summaryDTO']) else None)
+    csv_filter.set_column('calories', "{0:.0f}".format(details['summaryDTO']['calories']) if present('calories', details['summaryDTO']) else None)
     csv_filter.set_column('vo2max', str(actvty['vO2MaxValue']) if present('vO2MaxValue', actvty) else None)
-    csv_filter.set_column('aerobicEffect',
-                          str(round(details['summaryDTO']['trainingEffect'], 2)) if present('trainingEffect', details[
-                              'summaryDTO']) else None)
-    csv_filter.set_column('anaerobicEffect', str(round(details['summaryDTO']['anaerobicTrainingEffect'], 2)) if present(
-        'anaerobicTrainingEffect', details['summaryDTO']) else None)
-    csv_filter.set_column('averageRunCadence',
-                          str(round(details['summaryDTO']['averageRunCadence'], 2)) if present('averageRunCadence',
-                                                                                               details[
-                                                                                                   'summaryDTO']) else None)
-    csv_filter.set_column('maxRunCadence', str(details['summaryDTO']['maxRunCadence']) if present('maxRunCadence',
-                                                                                                  details[
-                                                                                                      'summaryDTO']) else None)
-    csv_filter.set_column('strideLength',
-                          str(round(details['summaryDTO']['strideLength'], 2)) if present('strideLength', details[
-                              'summaryDTO']) else None)
+    csv_filter.set_column('aerobicEffect', str(round(details['summaryDTO']['trainingEffect'], 2)) if present('trainingEffect', details['summaryDTO']) else None)
+    csv_filter.set_column('anaerobicEffect', str(round(details['summaryDTO']['anaerobicTrainingEffect'], 2)) if present('anaerobicTrainingEffect', details['summaryDTO']) else None)
+    csv_filter.set_column('averageRunCadence', str(round(details['summaryDTO']['averageRunCadence'], 2)) if present('averageRunCadence', details['summaryDTO']) else None)
+    csv_filter.set_column('maxRunCadence', str(details['summaryDTO']['maxRunCadence']) if present('maxRunCadence', details['summaryDTO']) else None)
+    csv_filter.set_column('strideLength', str(round(details['summaryDTO']['strideLength'], 2)) if present('strideLength', details['summaryDTO']) else None)
     csv_filter.set_column('steps', str(actvty['steps']) if present('steps', actvty) else None)
-    csv_filter.set_column('averageCadence', str(actvty['averageBikingCadenceInRevPerMinute']) if present(
-        'averageBikingCadenceInRevPerMinute', actvty) else None)
-    csv_filter.set_column('maxCadence',
-                          str(actvty['maxBikingCadenceInRevPerMinute']) if present('maxBikingCadenceInRevPerMinute',
-                                                                                   actvty) else None)
+    csv_filter.set_column('averageCadence', str(actvty['averageBikingCadenceInRevPerMinute']) if present('averageBikingCadenceInRevPerMinute', actvty) else None)
+    csv_filter.set_column('maxCadence', str(actvty['maxBikingCadenceInRevPerMinute']) if present('maxBikingCadenceInRevPerMinute', actvty) else None)
     csv_filter.set_column('strokes', str(actvty['strokes']) if present('strokes', actvty) else None)
-    csv_filter.set_column('averageTemperature',
-                          str(details['summaryDTO']['averageTemperature']) if present('averageTemperature',
-                                                                                      details['summaryDTO']) else None)
-    csv_filter.set_column('minTemperature', str(details['summaryDTO']['minTemperature']) if present('minTemperature',
-                                                                                                    details[
-                                                                                                        'summaryDTO']) else None)
-    csv_filter.set_column('maxTemperature', str(details['summaryDTO']['maxTemperature']) if present('maxTemperature',
-                                                                                                    details[
-                                                                                                        'summaryDTO']) else None)
+    csv_filter.set_column('averageTemperature', str(details['summaryDTO']['averageTemperature']) if present('averageTemperature', details['summaryDTO']) else None)
+    csv_filter.set_column('minTemperature', str(details['summaryDTO']['minTemperature']) if present('minTemperature', details['summaryDTO']) else None)
+    csv_filter.set_column('maxTemperature', str(details['summaryDTO']['maxTemperature']) if present('maxTemperature', details['summaryDTO']) else None)
     csv_filter.set_column('device', extract['device'] if extract['device'] else None)
     csv_filter.set_column('gear', extract['gear'] if extract['gear'] else None)
-    csv_filter.set_column('activityTypeKey', actvty['activityType']['typeKey'].title() if present('typeKey', actvty[
-        'activityType']) else None)
-    csv_filter.set_column('activityType', value_if_found_else_key(activity_type_name,
-                                                                  'activity_type_' + actvty['activityType'][
-                                                                      'typeKey']) if present('activityType',
-                                                                                             actvty) else None)
-    csv_filter.set_column('activityParent', value_if_found_else_key(activity_type_name,
-                                                                    'activity_type_' + parent_type_key) if parent_type_key else None)
-    csv_filter.set_column('eventTypeKey',
-                          actvty['eventType']['typeKey'].title() if present('typeKey', actvty['eventType']) else None)
-    csv_filter.set_column('eventType',
-                          value_if_found_else_key(event_type_name, actvty['eventType']['typeKey']) if present(
-                              'eventType', actvty) else None)
-    csv_filter.set_column('privacy', details['accessControlRuleDTO']['typeKey'] if present('typeKey', details[
-        'accessControlRuleDTO']) else None)
-    csv_filter.set_column('fileFormat', details['metadataDTO']['fileFormat']['formatKey'] if present('fileFormat',
-                                                                                                     details[
-                                                                                                         'metadataDTO']) and present(
-        'formatKey', details['metadataDTO']['fileFormat']) else None)
-    csv_filter.set_column('tz', details['timeZoneUnitDTO']['timeZone'] if present('timeZone',
-                                                                                  details['timeZoneUnitDTO']) else None)
+    csv_filter.set_column('activityTypeKey', actvty['activityType']['typeKey'].title() if present('typeKey', actvty['activityType']) else None)
+    csv_filter.set_column('activityType', value_if_found_else_key(activity_type_name, 'activity_type_' + actvty['activityType']['typeKey']) if present('activityType', actvty) else None)
+    csv_filter.set_column('activityParent', value_if_found_else_key(activity_type_name, 'activity_type_' + parent_type_key) if parent_type_key else None)
+    csv_filter.set_column('eventTypeKey', actvty['eventType']['typeKey'].title() if present('typeKey', actvty['eventType']) else None)
+    csv_filter.set_column('eventType', value_if_found_else_key(event_type_name, actvty['eventType']['typeKey']) if present('eventType', actvty) else None)
+    csv_filter.set_column('privacy', details['accessControlRuleDTO']['typeKey'] if present('typeKey', details['accessControlRuleDTO']) else None)
+    csv_filter.set_column('privacy', details['accessControlRuleDTO']['typeKey'] if present('typeKey', details['accessControlRuleDTO']) else None)
+    csv_filter.set_column('fileFormat', details['metadataDTO']['fileFormat']['formatKey'] if present('fileFormat', details['metadataDTO']) and present('formatKey', details['metadataDTO']['fileFormat']) else None)
+    csv_filter.set_column('tz', details['timeZoneUnitDTO']['timeZone'] if present('timeZone', details['timeZoneUnitDTO']) else None)
     csv_filter.set_column('tzOffset', extract['start_time_with_offset'].isoformat()[-6:])
     csv_filter.set_column('locationName', details['locationName'] if present('locationName', details) else None)
     csv_filter.set_column('startLatitudeRaw', str(start_latitude) if start_latitude else None)
@@ -732,8 +641,7 @@ def csv_write_record(csv_filter, extract, actvty, details, activity_type_name, e
     csv_filter.set_column('endLatitude', trunc6(end_latitude) if end_latitude else None)
     csv_filter.set_column('endLongitudeRaw', str(end_longitude) if end_longitude else None)
     csv_filter.set_column('endLongitude', trunc6(end_longitude) if end_longitude else None)
-    csv_filter.set_column('sampleCount', str(extract['samples']['metricsCount']) if present('metricsCount', extract[
-        'samples']) else None)
+    csv_filter.set_column('sampleCount', str(extract['samples']['metricsCount']) if present('metricsCount', extract['samples']) else None)
 
     csv_filter.write_row()
 
@@ -754,8 +662,7 @@ def extract_device(device_dict, details, start_time_seconds, args, http_caller, 
         return None
 
     metadata = details['metadataDTO']
-    device_app_inst_id = metadata['deviceApplicationInstallationId'] if present('deviceApplicationInstallationId',
-                                                                                metadata) else None
+    device_app_inst_id = metadata['deviceApplicationInstallationId'] if present('deviceApplicationInstallationId', metadata) else None
     if device_app_inst_id:
         if device_app_inst_id not in device_dict:
             # observed from my stock of activities:

--- a/gcexport.py
+++ b/gcexport.py
@@ -41,6 +41,7 @@ import string
 import sys
 import unicodedata
 import zipfile
+
 from filtering import update_download_stats, read_exclude
 
 python3 = sys.version_info.major == 3


### PR DESCRIPTION
### Summary
Exclude activities from the download by a given json file with an array of activity IDs.

### Use Case
The user wants the ability to exclude activities by its ID from the download. This has to be independent from the already downloaded activity files; activities have to be excluded, even if the activity file does not exist in the given download folder. In addition to that, the user expects a managed json file with the list of downloaded activities, which can be used as input for the exclude filter. The file should be stored in the download folder and has to be named "downloaded_ids.json".

### Usage by examples:
1) Download the last 10 activities, add IDs to downloads/downloaded_ids.json
```
$ python gcexport.py -f tcx -d downloads  -s in -fp -c 10
```

2) Download just the 11th activity. Add its ID to downloads/downloaded_ids.json
```
$ python gcexport.py -f tcx -d downloads  -s in -fp -c 11 -ex downloads/downloaded_ids.json
```

3) Download the last 100 activities, skip the last 10, exclude activity '6540566061'
```
$ echo '{"ids": ["6540566061"]}' > ex.json
$ python gcexport.py -f tcx -d downloads  -s in -fp -c 100 -sa 10 -ex ex.json
```

### Implementation details
The large processing loop is now split into two parts. First the data will be collected and the action for every activity will be determined (skip, exclude and download). The second part is the loop over this action list to output and download the files. 
With every successful download the json file 'downloaded_ids.json' will be extended with the activity ID (skipping doesn't do this).
Beside this, there is just one change in the former behavior: the userstats will always be downloaded, not only for 'count all'. This is obligatory to get the activity IDs. It will be also downloaded, even if the exclude filter is not used. In my opinion, this is more transparent to the user, because the userstats.json is always up-to-date. On the other hand, there is at least one request more, but this should be acceptable at all.

### One full example output
```
$ cat downloads/downloaded_ids.json
{"ids": ["6540566061", "6563511175"]}
$ python gcexport.py -f tcx -d downloads -s in -fp -c 4 -sa 2 -ex downloads/downloaded_ids.json
Welcome to Garmin Connect Exporter!
[WARNING] Output directory downloads already exists. Will skip already-downloaded files and append to the CSV file.
Connecting to Garmin Connect... Done.
Requesting Login ticket... Done. Ticket=ST-03005971-4rvXNVtz3YV34NHoXFAV-cas
Authenticating... Done.
Getting display name... Done. displayName=6b970a16-d759-4e7f-8b1e-e6c170e96ecd
Fetching user stats... Done.
Querying list of activities 1..4... Done.
Skipping   : Garmin Connect activity (1/4) [6574633315] 
Excluding  : Garmin Connect activity (2/4) [6563511175] 
Excluding  : Garmin Connect activity (3/4) [6540566061] 
Downloading: Garmin Connect activity (4/4) [6510862175] Gelnhausen Radfahren
        2021-03-29T06:55:58+02:00, 01:23:23, 29.279km
Done!
```



