### PR TITLE
Add activity typeId filtering

### DIFF
--- a/gcexport.py
+++ b/gcexport.py
@@ -1237,12 +1237,7 @@ def main(argv):
 
     activities = fetch_activity_list(args, total_to_download)
 
-    #if args.type_filter is not None:
-    #    type_filter = args.type_filter.split(',')
-    #else:
-    #    type_filter = None
-
-    type_filter = args.type_filter.split(',')  if args.type_filter is not None else None
+    type_filter = list(map(int,args.type_filter.split(',')))  if args.type_filter is not None else None
 
     action_list = annotate_activity_list(activities, args.start_activity_no, exclude_list, type_filter)
 
@@ -1272,7 +1267,7 @@ def main(argv):
         # Action: Filtered out by typeID
         if action == 'f':
             # Display which entry we're skipping.
-            print('Filtering out due to typeID   : Garmin Connect activity ', end='')
+            print('Filtering out due to typeID, {} not in {}   : Garmin Connect activity '.format(actvty['activityType']['typeId'], type_filter), end='')
             print('(', current_index, '/', len(action_list), ') ', sep='', end='')
             print('[', actvty['activityId'], ']', sep='')
             continue

--- a/gcexport.py
+++ b/gcexport.py
@@ -1267,9 +1267,8 @@ def main(argv):
         # Action: Filtered out by typeID
         if action == 'f':
             # Display which entry we're skipping.
-            print('Filtering out due to typeID, {} not in {}   : Garmin Connect activity '.format(actvty['activityType']['typeId'], type_filter), end='')
-            print('(', current_index, '/', len(action_list), ') ', sep='', end='')
-            print('[', actvty['activityId'], ']', sep='')
+            print(f'Filtering out due to typeID, {actvty['activityType']['typeId']} not in {type_filter}   : Garmin Connect activity ', end='')
+            print(f'({current_index}/{len(action_list)}) [{actvty['activityId']}]')
             continue
 
         # Action: download

--- a/gcexport.py
+++ b/gcexport.py
@@ -1237,7 +1237,7 @@ def main(argv):
 
     activities = fetch_activity_list(args, total_to_download)
 
-    type_filter = list(map(int,args.type_filter.split(',')))  if args.type_filter is not None else None
+    type_filter = map(int,args.type_filter.split(','))  if args.type_filter is not None else None
 
     action_list = annotate_activity_list(activities, args.start_activity_no, exclude_list, type_filter)
 


### PR DESCRIPTION
Adds the ability to filter based on typeIds as requested in #71. The new --type_filter argument allows you to pass a list of typeIds and only pull activities matching those Ids. 

For example:
```$ python gcexport.py -tf 3```
Results in:
```Filtering out due to typeID, 1 not in [3]   : Garmin Connect activity (1/1) [8791243351```