### PR TITLE
Remove Python2 leftovers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ venv/
 *.pyc
 *.log
 lint*.txt
+*.swp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,6 @@ And the effort to still support Python 2 has become to big (see https://github.c
 so to protect users from getting HTTP errors/exceptions with Python 2, the script
 purposely denies running with Python 2.
 
-The code that would support Python 2 will still be around for some time before
-I will clean up the code.
-
 ## Getting started
 
 ### Pull requests

--- a/gcexport.py
+++ b/gcexport.py
@@ -388,10 +388,7 @@ def epoch_seconds_from_summary(summary):
         return summary['beginTimestamp'] // 1000
     elif present('startTimeLocal', summary) and present('startTimeGMT', summary):
         dt = offset_date_time(summary['startTimeLocal'], summary['startTimeGMT'])
-        # with Python 3 this can be simplified to datetime.timestamp()
-        utc = FixedOffset(0, "UTC")
-        seconds = (dt - datetime(1970, 1, 1, tzinfo = utc)).total_seconds()
-        return int(seconds)
+        return int(dt.timestamp())
     else:
         logging.info('No timestamp found in activity %s', summary['activityId'])
         return None

--- a/gcexport.py
+++ b/gcexport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -18,9 +18,6 @@ Activity & event types:
     https://connect.garmin.com/modern/main/js/properties/event_types/event_types.properties
     https://connect.garmin.com/modern/main/js/properties/activity_types/activity_types.properties
 """
-
-# this avoids different pylint behaviour for python 2 and 3
-from __future__ import print_function
 
 from datetime import datetime, timedelta, tzinfo
 from getpass import getpass
@@ -44,26 +41,16 @@ import zipfile
 
 from filtering import update_download_stats, read_exclude
 
-python3 = sys.version_info.major == 3
-if python3:
-    import http.cookiejar
-    import urllib.error
-    import urllib.parse
-    import urllib.request
-    import urllib
-    from urllib.parse import urlencode
-    from urllib.request import Request, HTTPError, URLError
+import http.cookiejar
+import urllib.error
+import urllib.parse
+import urllib.request
+import urllib
+from urllib.parse import urlencode
+from urllib.request import Request, HTTPError, URLError
 
-    COOKIE_JAR = http.cookiejar.CookieJar()
-    OPENER = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(COOKIE_JAR), urllib.request.HTTPSHandler(debuglevel=0))
-else:
-    import cookielib
-    import urllib2
-    from urllib import urlencode
-    from urllib2 import Request, HTTPError, URLError
-
-    COOKIE_JAR = cookielib.CookieJar()
-    OPENER = urllib2.build_opener(urllib2.HTTPCookieProcessor(COOKIE_JAR), urllib2.HTTPSHandler(debuglevel=0))
+COOKIE_JAR = http.cookiejar.CookieJar()
+OPENER = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(COOKIE_JAR), urllib.request.HTTPSHandler(debuglevel=0))
 
 SCRIPT_VERSION = '3.3.0'
 
@@ -239,16 +226,11 @@ def http_req(url, post=None, headers=None):
         like Gecko) Chrome/54.0.2816.0 Safari/537.36')
     request.add_header('nk', 'NT')  # necessary since 2021-02-23 to avoid http error code 402
     if headers:
-        if python3:
-            for header_key, header_value in headers.items():
-                request.add_header(header_key, header_value)
-        else:
-            for header_key, header_value in headers.iteritems():
-                request.add_header(header_key, header_value)
+        for header_key, header_value in headers.items():
+            request.add_header(header_key, header_value)
     if post:
         post = urlencode(post)  # Convert dictionary to POST parameter string.
-        if python3:
-            post = post.encode("utf-8")
+        post = post.encode("utf-8")
     start_time = timer()
     try:
         response = OPENER.open(request, data=post)
@@ -283,10 +265,7 @@ def http_req(url, post=None, headers=None):
 
 def http_req_as_string(url, post=None, headers=None):
     """Helper function that makes the HTTP requests, returning a string instead of bytes."""
-    if python3:
-        return http_req(url, post, headers).decode()
-    else:
-        return http_req(url, post, headers)
+    return http_req(url, post, headers).decode()
 
 
 # idea stolen from https://stackoverflow.com/a/31852401/3686
@@ -356,7 +335,7 @@ class FixedOffset(tzinfo):
     """Fixed offset in minutes east from UTC."""
 
     def __init__(self, offset, name):
-        super(FixedOffset, self).__init__()
+        super().__init__()
         self.__offset = timedelta(minutes=offset)
         self.__name = name
 
@@ -442,7 +421,7 @@ def pace_or_speed_formatted(type_id, parent_type_id, mps):
     return "{0:.1f}".format(round(kmh, 1))
 
 
-class CsvFilter(object):
+class CsvFilter:
     """Collects, filters and writes CSV."""
 
     def __init__(self, csv_file, csv_header_properties):
@@ -472,11 +451,7 @@ class CsvFilter(object):
         the record prepared for the next write_row call
         """
         if value and name in self.__csv_columns:
-            if python3:
-                self.__current_row[self.__csv_headers[name]] = value
-            else:
-                # must encode in UTF-8 because the Python 2 'csv' module doesn't support unicode
-                self.__current_row[self.__csv_headers[name]] = value.encode('utf8')
+            self.__current_row[self.__csv_headers[name]] = value
 
     def is_column_active(self, name):
         """Return True if the column is present in the header template"""
@@ -536,10 +511,7 @@ def login_to_garmin_connect(args):
     """
     Perform all HTTP requests to login to Garmin Connect.
     """
-    if python3:
-        username = args.username if args.username else input('Username: ')
-    else:
-        username = args.username if args.username else raw_input('Username: ')
+    username = args.username if args.username else input('Username: ')
     password = args.password if args.password else getpass()
 
     logging.debug("Login params: %s", urlencode(DATA))
@@ -1175,7 +1147,7 @@ def main(argv):
 
     print('Welcome to Garmin Connect Exporter!')
 
-    if not python3:
+    if sys.version_info.major < 3:
         print('Please upgrade to Python 3.x, version', python_version(), 'isn\'t supported anymore, see https://github.com/pe-st/garmin-connect-export/issues/64')
         sys.exit(1)
 
@@ -1200,10 +1172,7 @@ def main(argv):
     csv_filename = args.directory + '/activities.csv'
     csv_existed = os.path.isfile(csv_filename)
 
-    if python3:
-        csv_file = open(csv_filename, mode='a', encoding='utf-8')
-    else:
-        csv_file = open(csv_filename, 'a')
+    csv_file = open(csv_filename, mode='a', encoding='utf-8')
     csv_filter = CsvFilter(csv_file, args.template)
 
     # Write header to CSV file

--- a/gcexport.py
+++ b/gcexport.py
@@ -191,9 +191,8 @@ def write_to_file(filename, content, mode='w', file_time=None):
     Helper function that persists content to a file.
 
     :param filename:     name of the file to write
-    :param content:      content to write; with Python 2 always of type 'str',
-                         with Python 3 it can be 'bytes' or 'str'. If it's
-                         'bytes' and the mode 'w', it will be converted/decoded
+    :param content:      content to write; can be 'bytes' or 'str'.
+                         If it's 'bytes' and the mode 'w', it will be converted/decoded
     :param mode:         'w' or 'wb'
     :param file_time:    if given use as timestamp for the file written (in seconds since 1970-01-01)
     """
@@ -218,7 +217,7 @@ def http_req(url, post=None, headers=None):
     :param url:          URL for the request
     :param post:         dictionary of POST parameters
     :param headers:      dictionary of headers
-    :return: response body (type 'str' with Python 2, type 'bytes' with Python 3
+    :return: response body (type 'bytes')
     """
     request = Request(url)
     # Tell Garmin we're some supported browser.

--- a/gcexport.py
+++ b/gcexport.py
@@ -46,8 +46,9 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import urllib
+from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
-from urllib.request import Request, HTTPError, URLError
+from urllib.request import Request
 
 COOKIE_JAR = http.cookiejar.CookieJar()
 OPENER = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(COOKIE_JAR), urllib.request.HTTPSHandler(debuglevel=0))

--- a/gcexport.py
+++ b/gcexport.py
@@ -339,15 +339,12 @@ class FixedOffset(tzinfo):
         self.__name = name
 
     def utcoffset(self, dt):
-        del dt # unused
         return self.__offset
 
     def tzname(self, dt):
-        del dt # unused
         return self.__name
 
     def dst(self, dt):
-        del dt # unused
         return timedelta(0)
 
 

--- a/gcexport_test.py
+++ b/gcexport_test.py
@@ -6,12 +6,7 @@ py.test gcexport_test.py
 """
 
 from gcexport import *
-try:
-    ## for Python 2
-    from StringIO import StringIO
-except ImportError:
-    ## for Python 3
-    from io import StringIO
+from io import StringIO
 
 
 def test_pace_or_speed_raw_cycling():


### PR DESCRIPTION
# Story

This PR removes all traces of Python2 support

# Background

Python2 is not supported since [v3.2.0](https://github.com/pe-st/garmin-connect-export/releases/tag/v3.2.0) (via 525e3fd). Rationales: #64

# Details

- Removed deprecated conditional statements
- Refactoring the codebase to the Python 3 standard
- Updated `CONTRIBUTING.md`
- Added .swp extension to `.gitignore` file _(unrelated to PR)_

### Note:
Python 2 is still referenced in the documentation. These references are intended to be kept for some time.
https://github.com/pe-st/garmin-connect-export/blob/0b114e722b73da04e905a5c50caf4b8b7edeaff8/CONTRIBUTING.md?plain=1#L11-L16