### PR TITLE
Add a new option `--logpath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ You will need a little experience running things from the command line to use th
 usage: gcexport.py [-h] [--version] [-v] [--username USERNAME]
                    [--password PASSWORD] [-c COUNT] [-e EXTERNAL] [-a ARGS]
                    [-f {gpx,tcx,original,json}] [-d DIRECTORY] [-s SUBDIR]
-                   [-u] [-ot] [--desc [DESC]] [-t TEMPLATE] [-fp]
-                   [-sa START_ACTIVITY_NO] [-ex FILE]
+                   [-lp LOGPATH] [-u] [-ot] [--desc [DESC]] [-t TEMPLATE]
+                   [-fp] [-sa START_ACTIVITY_NO] [-ex FILE]
 
 Garmin Connect Exporter
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --version             print version and exit
   -v, --verbosity       increase output and log verbosity, save more intermediate files
@@ -76,6 +76,8 @@ optional arguments:
   -s SUBDIR, --subdir SUBDIR
                         the subdirectory for activity files (tcx, gpx etc.), supported placeholders are {YYYY} and {MM}
                         (default: export directory)
+  -lp LOGPATH, --logpath LOGPATH
+                        the directory to store logfiles (default: same as for --directory
   -u, --unzip           if downloading ZIP files (format: 'original'), unzip the file and remove the ZIP file
   -ot, --originaltime   will set downloaded (and possibly unzipped) file time to the activity start time
   --desc [DESC]         append the activity's description to the file name of the download; limit size if number is given
@@ -85,7 +87,7 @@ optional arguments:
   -sa START_ACTIVITY_NO, --start_activity_no START_ACTIVITY_NO
                         give index for first activity to import, i.e. skipping the newest activities
   -ex FILE, --exclude FILE
-                        Json file with Array of activity IDs to exclude from download.
+                        JSON file with Array of activity IDs to exclude from download.
                         Format example: {"ids": ["6176888711"]}
 ```
 

--- a/gcexport.py
+++ b/gcexport.py
@@ -931,6 +931,10 @@ def export_data_file(activity_id, activity_details, args, file_time, append_desc
 
 def setup_logging(args):
     """Setup logging"""
+    # make sure the log file can be created
+    if not os.path.isdir(args.directory):
+        os.makedirs(args.directory)
+
     logging.basicConfig(
         filename = os.path.join(args.directory, 'gcexport.log'),
         level=logging.DEBUG,

--- a/gcexport.py
+++ b/gcexport.py
@@ -929,10 +929,10 @@ def export_data_file(activity_id, activity_details, args, file_time, append_desc
     # Inform the main program that the file is new
     return True
 
-def setup_logging():
+def setup_logging(args):
     """Setup logging"""
     logging.basicConfig(
-        filename='gcexport.log',
+        filename = os.path.join(args.directory, 'gcexport.log'),
         level=logging.DEBUG,
         format='%(asctime)s [%(levelname)-7.7s] %(message)s'
     )
@@ -1168,9 +1168,9 @@ def main(argv):
     """
     Main entry point for gcexport.py
     """
-    setup_logging()
-    logging.info("Starting %s version %s, using Python version %s", argv[0], SCRIPT_VERSION, python_version())
     args = parse_arguments(argv)
+    setup_logging(args)
+    logging.info("Starting %s version %s, using Python version %s", argv[0], SCRIPT_VERSION, python_version())
     logging_verbosity(args.verbosity)
 
     print('Welcome to Garmin Connect Exporter!')

--- a/gcexport.py
+++ b/gcexport.py
@@ -510,9 +510,9 @@ def parse_arguments(argv):
         help="export format; can be 'gpx', 'tcx', 'original' or 'json' (default: 'gpx')")
     parser.add_argument('-d', '--directory', default=activities_directory,
         help='the directory to export to (default: \'./YYYY-MM-DD_garmin_connect_export\')')
-    parser.add_argument('-s', "--subdir",
-        help="the subdirectory for activity files (tcx, gpx etc.), supported placeholders are {YYYY} and {MM}"
-                        " (default: export directory)" )
+    parser.add_argument('-s', '--subdir',
+        help='the subdirectory for activity files (tcx, gpx etc.), supported placeholders are {YYYY} and {MM}'
+                        ' (default: export directory)')
     parser.add_argument('-l', '--logpath',
         help='the directory to store logfiles (default: same as for --directory')
     parser.add_argument('-u', '--unzip', action='store_true',
@@ -524,12 +524,12 @@ def parse_arguments(argv):
     parser.add_argument('-t', '--template', default=CSV_TEMPLATE,
         help='template file with desired columns for CSV output')
     parser.add_argument('-fp', '--fileprefix', action='count', default=0,
-        help="set the local time as activity file name prefix")
+        help='set the local time as activity file name prefix')
     parser.add_argument('-sa', '--start_activity_no', type=int, default=1,
-        help="give index for first activity to import, i.e. skipping the newest activities")
-    parser.add_argument('-ex', '--exclude', metavar="FILE",
-        help="Json file with Array of activity IDs to exclude from download. "
-                        "Format example: {\"ids\": [\"6176888711\"]}")
+        help='give index for first activity to import, i.e. skipping the newest activities')
+    parser.add_argument('-ex', '--exclude', metavar='FILE',
+        help='JSON file with Array of activity IDs to exclude from download. '
+                        'Format example: {"ids": ["6176888711"]}')
 
     return parser.parse_args(argv[1:])
 

--- a/gcexport.py
+++ b/gcexport.py
@@ -513,6 +513,8 @@ def parse_arguments(argv):
     parser.add_argument('-s', "--subdir",
         help="the subdirectory for activity files (tcx, gpx etc.), supported placeholders are {YYYY} and {MM}"
                         " (default: export directory)" )
+    parser.add_argument('-l', '--logpath',
+        help='the directory to store logfiles (default: same as for --directory')
     parser.add_argument('-u', '--unzip', action='store_true',
         help='if downloading ZIP files (format: \'original\'), unzip the file and remove the ZIP file')
     parser.add_argument('-ot', '--originaltime', action='store_true',
@@ -931,12 +933,12 @@ def export_data_file(activity_id, activity_details, args, file_time, append_desc
 
 def setup_logging(args):
     """Setup logging"""
-    # make sure the log file can be created
-    if not os.path.isdir(args.directory):
-        os.makedirs(args.directory)
+    logpath = args.logpath if args.logpath else args.directory
+    if not os.path.isdir(logpath):
+        os.makedirs(logpath)
 
     logging.basicConfig(
-        filename = os.path.join(args.directory, 'gcexport.log'),
+        filename = os.path.join(logpath, 'gcexport.log'),
         level=logging.DEBUG,
         format='%(asctime)s [%(levelname)-7.7s] %(message)s'
     )

--- a/gcexport.py
+++ b/gcexport.py
@@ -513,7 +513,7 @@ def parse_arguments(argv):
     parser.add_argument('-s', '--subdir',
         help='the subdirectory for activity files (tcx, gpx etc.), supported placeholders are {YYYY} and {MM}'
                         ' (default: export directory)')
-    parser.add_argument('-l', '--logpath',
+    parser.add_argument('-lp', '--logpath',
         help='the directory to store logfiles (default: same as for --directory')
     parser.add_argument('-u', '--unzip', action='store_true',
         help='if downloading ZIP files (format: \'original\'), unzip the file and remove the ZIP file')


### PR DESCRIPTION
# Summary

This new option allows declaring a target directory for log files.
The default value is pulled from the `--directory` option.

## IMPORTANT
This is a breaking change.

### Old default behavior
`gcexpert.log` is stored in the current application directory

### New default behavior
`gcepxport.log` is stored in the target directory of `--directory`, so the default is `./YYYY-MM-DD_garmin_connect_export`

## Motivation
By default, the application stores the exported activities in daily directories such as `YYYY-MM-DD_garmin_connect_export`.
By storing daily log files in the same directory as the activities, the user would have the full package of all files created by the app.

It is also worth noting that many operating systems have dedicated log folders, e.g. `/var/log/` etc. This option allows for storing logs in such locations.

## Background
Initial commit 7ab7125 by @cristian5th was cherry-picked from PR #66 where you can also find more discussion about this option.