### PR TITLE
Make string concatenation more compact by introducing f-strings

### DIFF
--- a/filtering.py
+++ b/filtering.py
@@ -17,11 +17,11 @@ def read_exclude(file):
 
     if not path.exists(file):
         print("File not found:", file)
-        return None
+        return
 
     if not path.isfile(file):
         print("Not a file:", file)
-        return None
+        return
 
     with open(file, 'r') as f:
 
@@ -32,7 +32,7 @@ def read_exclude(file):
         # except JSONDecodeError: only in Python3, use the more generic type instead
         except ValueError:
             print("No valid json in:", file)
-            return None
+            return
 
 
 def update_download_stats(activity_id, dir):

--- a/filtering.py
+++ b/filtering.py
@@ -16,11 +16,11 @@ def read_exclude(file):
     """
 
     if not path.exists(file):
-        print("File not found: " + file)
+        print("File not found:", file)
         return None
 
     if not path.isfile(file):
-        print("Not a file: " + file)
+        print("Not a file:", file)
         return None
 
     with open(file, 'r') as f:
@@ -31,7 +31,7 @@ def read_exclude(file):
 
         # except JSONDecodeError: only in Python3, use the more generic type instead
         except ValueError:
-            print("No valid json in: " + file)
+            print("No valid json in:", file)
             return None
 
 

--- a/gcexport.py
+++ b/gcexport.py
@@ -1223,7 +1223,7 @@ def main(argv):
         # Action: download
         # Display which entry we're working on.
         print('Downloading: Garmin Connect activity ', end='')
-        print(f"({current_index}/{len(action_list)}) [{actvty['activityId']}] actvty['activityName']")
+        print(f"({current_index}/{len(action_list)}) [{actvty['activityId']}] {actvty['activityName']}")
 
         # Retrieve also the detail data from the activity (the one displayed on
         # the https://connect.garmin.com/modern/activity/xxx page), because some

--- a/gcexport.py
+++ b/gcexport.py
@@ -258,7 +258,7 @@ def http_req(url, post=None, headers=None):
         logging.info('Got 204 for %s, returning empty response', url)
         return b''
     elif response.getcode() != 200:
-        raise Exception('Bad return code (' + str(response.getcode()) + ') for: ' + url)
+        raise Exception(f'Bad return code ({response.getcode()}) for: {url}')
 
     return response.read()
 
@@ -372,7 +372,7 @@ def datetime_from_iso(iso_date_time):
     pattern = re.compile(r"(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})(\.\d+)?")
     match = pattern.match(iso_date_time)
     if not match:
-        raise Exception('Invalid ISO timestamp ' + iso_date_time + '.')
+        raise Exception(f'Invalid ISO timestamp {iso_date_time}.')
     micros = match.group(3) if match.group(3) else ".0"
     iso_with_micros = match.group(1) + ' ' + match.group(2) + micros
     return datetime.strptime(iso_with_micros, "%Y-%m-%d %H:%M:%S.%f")
@@ -859,7 +859,7 @@ def export_data_file(activity_id, activity_details, args, file_time, append_desc
                 data = ''
             else:
                 logging.info('Got %s for %s', ex.code, download_url)
-                raise Exception('Failed. Got an HTTP error ' + str(ex.code) + ' for ' + download_url)
+                raise Exception(f'Failed. Got an HTTP error {ex.code} for {download_url}')
     else:
         data = activity_details
 
@@ -1100,8 +1100,7 @@ def fetch_details(activity_id, http_caller):
             logging.info("Retrying activity details download %s", URL_GC_ACTIVITY + str(activity_id))
             tries -= 1
             if tries == 0:
-                raise Exception(
-                    'Didn\'t get "summaryDTO" after ' + str(MAX_TRIES) + ' tries for ' + str(activity_id))
+                raise Exception(f'Didn\'t get "summaryDTO" after {MAX_TRIES} tries for {activity_id}')
     return activity_details, details
 
 

--- a/gcexport.py
+++ b/gcexport.py
@@ -1213,24 +1213,20 @@ def main(argv):
         if action == 's':
             # Display which entry we're skipping.
             print('Skipping   : Garmin Connect activity ', end='')
-            print('(', current_index, '/', len(action_list), ') ', sep='', end='')
-            print('[', actvty['activityId'], ']', sep='')
+            print(f"({current_index}/{len(action_list)}) [{actvty['activityId']}]")
             continue
 
         # Action: excluding
         if action == 'e':
             # Display which entry we're skipping.
             print('Excluding  : Garmin Connect activity ', end='')
-            print('(', current_index, '/', len(action_list), ') ', sep='', end='')
-            print('[', actvty['activityId'], '] ', sep='')
+            print(f"({current_index}/{len(action_list)}) [{actvty['activityId']}]")
             continue
 
         # Action: download
         # Display which entry we're working on.
         print('Downloading: Garmin Connect activity ', end='')
-        print('(', current_index, '/', len(action_list), ') ', sep='', end='')
-        print('[', actvty['activityId'], '] ', sep='', end='')
-        print(actvty['activityName'])
+        print(f"({current_index}/{len(action_list)}) [{actvty['activityId']}] actvty['activityName']")
 
         # Retrieve also the detail data from the activity (the one displayed on
         # the https://connect.garmin.com/modern/activity/xxx page), because some

--- a/gcexport.py
+++ b/gcexport.py
@@ -849,8 +849,7 @@ def export_data_file(activity_id, activity_details, args, file_time, append_desc
                 # are no tracks. One could be generated here, but that's a bit much. Use the GPX
                 # format if you want actual data in every file, as I believe Garmin provides a GPX
                 # file for every activity.
-                logging.info('Writing empty file since Garmin did not generate a TCX file for this \
-                             activity...')
+                logging.info('Writing empty file since Garmin did not generate a TCX file for this activity...')
                 data = ''
             elif ex.code == 404 and args.format == 'original':
                 # For manual activities (i.e., entered in online without a file upload), there is

--- a/gcexport.py
+++ b/gcexport.py
@@ -374,7 +374,7 @@ def datetime_from_iso(iso_date_time):
     if not match:
         raise Exception(f'Invalid ISO timestamp {iso_date_time}.')
     micros = match.group(3) if match.group(3) else ".0"
-    iso_with_micros = match.group(1) + ' ' + match.group(2) + micros
+    iso_with_micros = f'{match.group(1)} {match.group(2)}{micros}'
     return datetime.strptime(iso_with_micros, "%Y-%m-%d %H:%M:%S.%f")
 
 
@@ -457,7 +457,7 @@ def parse_arguments(argv):
     Setup the argument parser and parse the command line arguments.
     """
     current_date = datetime.now().strftime('%Y-%m-%d')
-    activities_directory = './' + current_date + '_garmin_connect_export'
+    activities_directory = f'./{current_date}_garmin_connect_export'
 
     parser = argparse.ArgumentParser(description='Garmin Connect Exporter')
 
@@ -537,7 +537,7 @@ def login_to_garmin_connect(args):
 
     print('Requesting Login ticket...', end='')
     logging.info('Requesting Login ticket')
-    login_response = http_req_as_string(URL_GC_LOGIN + '#', post_data, headers)
+    login_response = http_req_as_string(f'{URL_GC_LOGIN}#', post_data, headers)
 
     for cookie in COOKIE_JAR:
         logging.debug("Cookie %s : %s", cookie.name, cookie.value)
@@ -554,8 +554,8 @@ def login_to_garmin_connect(args):
     print(' Done. Ticket=', login_ticket, sep='')
 
     print("Authenticating...", end='')
-    logging.info('Authentication URL %s', URL_GC_POST_AUTH + 'ticket=' + login_ticket)
-    http_req(URL_GC_POST_AUTH + 'ticket=' + login_ticket)
+    logging.info('Authentication URL %s', f'{URL_GC_POST_AUTH}ticket={login_ticket}')
+    http_req(f'{URL_GC_POST_AUTH}ticket={login_ticket}')
     print(' Done.')
 
 
@@ -1088,7 +1088,7 @@ def fetch_details(activity_id, http_caller):
     details = None
     tries = MAX_TRIES
     while tries > 0:
-        activity_details = http_caller(URL_GC_ACTIVITY + str(activity_id))
+        activity_details = http_caller(f'{URL_GC_ACTIVITY}{activity_id}')
         details = json.loads(activity_details)
         # I observed a failure to get a complete JSON detail in about 5-10 calls out of 1000
         # retrying then statistically gets a better JSON ;-)


### PR DESCRIPTION
F-strings were introduced in Python 3.6 and are a great way to make string concatenation more compact.
They also win in performance benchmarks.

This PR also fixes the log message that contains redundant whitespaces (dbcf8f0).

I also found a potential bug in the code. Please see the comment.