### PR TITLE
Print error instead of exception in fetch_details

### DIFF
--- a/gcexport.py
+++ b/gcexport.py
@@ -1112,7 +1112,8 @@ def fetch_details(activity_id, http_caller):
             logging.info("Retrying activity details download %s", URL_GC_ACTIVITY + str(activity_id))
             tries -= 1
             if tries == 0:
-                raise Exception(f'Didn\'t get "summaryDTO" after {MAX_TRIES} tries for {activity_id}')
+                print('Exception: didn\'t get "summaryDTO" after {MAX_TRIES} tries for {activity_id}')
+                pass
     return activity_details, details
 
 


### PR DESCRIPTION
This commit converts the raise exception statement inside the
fetch_details function into a print statement, so that when
working on multi entries (and just some fails) the others can be
processed in any case.
