### PR TITLE
Feature: Add date filter flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ You will need a little experience running things from the command line to use th
 
 ```
 usage: gcexport.py [-h] [--version] [-v] [--username USERNAME]
-                   [--password PASSWORD] [-c COUNT] [-e EXTERNAL] [-a ARGS]
+                   [--password PASSWORD] [-c COUNT] 
+                   [-sd START_DATE] [-ed END_DATE] 
+                   [-e EXTERNAL] [-a ARGS]
                    [-f {gpx,tcx,original,json}] [-d DIRECTORY] [-s SUBDIR]
                    [-lp LOGPATH] [-u] [-ot] [--desc [DESC]] [-t TEMPLATE]
                    [-fp] [-sa START_ACTIVITY_NO] [-ex FILE]
@@ -66,6 +68,10 @@ optional arguments:
   --password PASSWORD   your Garmin Connect password (otherwise, you will be prompted)
   -c COUNT, --count COUNT
                         number of recent activities to download, or 'all' (default: 1)
+  -sd START_DATE, --start_date START_DATE
+                        the start date to get activities from (inclusive). Format example: 2023-07-31
+  -ed END_DATE, --end_date END_DATE
+                        the end date to get activities to (inclusive). Format example: 2023-07-31
   -e EXTERNAL, --external EXTERNAL
                         path to external program to pass CSV file too
   -a ARGS, --args ARGS  additional arguments to pass to external program
@@ -104,6 +110,8 @@ optional arguments:
 
 - `python gcexport.py -d ~/MyActivities -c 3 -f original -u --username bobbyjoe --password bestpasswordever1`  
   will download your three most recent activities in the FIT file format (or whatever they were uploaded as) into the `~/MyActivities` directory (unless they already exist). Using the `--password` flags is not recommended because your password will be stored in your command line history. Instead, omit it to be prompted (and note that nothing will be displayed when you type your password). Equally you might not want to have the username stored in your command line history; in this case avoid also to give the `--username` option, and you'll be prompted for it. Note also that depending on the age of your garmin account your username is the email address (I myself still can login both with username and email address, but I've had a report that for some users the email address is mandatory to login).
+
+- `python gcexport.py -c all --start_date 2023-07-31 --end_date 2023-08-03` will download all activities from July 31st through August 3rd (the range is inclusive). These start and end date flags may be used together or individually. They may also be used in combination with `--count` and `start_activity_no`.
 
 Alternatively, you may run it with `./gcexport.py` if you set the file as executable (i.e., `chmod u+x gcexport.py`).
 

--- a/gcexport.py
+++ b/gcexport.py
@@ -475,6 +475,10 @@ def parse_arguments(argv):
         help='your Garmin Connect password (otherwise, you will be prompted)')
     parser.add_argument('-c', '--count', default='1',
         help='number of recent activities to download, or \'all\' (default: 1)')
+    parser.add_argument('-sd', '--start_date', default='',
+        help='the start date to get activities from (inclusive). Format example: 2023-07-31')
+    parser.add_argument('-ed', '--end_date', default='',
+        help='the end date to get activities to (inclusive). Format example: 2023-07-31')
     parser.add_argument('-e', '--external',
         help='path to external program to pass CSV file too')
     parser.add_argument('-a', '--args',
@@ -1051,6 +1055,11 @@ def fetch_activity_chunk(args, num_to_download, total_downloaded):
     """
 
     search_params = {'start': total_downloaded, 'limit': num_to_download}
+    if args.start_date != "":
+        search_params['startDate'] = args.start_date
+    if args.end_date != "":
+        search_params['endDate'] = args.end_date
+    
     # Query Garmin Connect
     print('Querying list of activities ', total_downloaded + 1, '..', total_downloaded + num_to_download, '...', sep='', end='')
     logging.info('Activity list URL %s', URL_GC_LIST + urlencode(search_params))


### PR DESCRIPTION
This PR implements a new feature. The flags `start_date` and `end_date` are simply passed on to the query sent to Garmin when fetching the activity list. This feature is useful both when fetching all historical data for the first time (I sometimes find dates more intuitive than activity count) and when fetching incrementally (the user only needs to keep track of when the script was last run).

I've tested it with my data/account and it seems to work as expected, also in combination with the `count` and `start_activity_no` flags which have related functionality.