### PR TITLE
Add argument to load/store Garmin SSO data

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ usage: gcexport.py [-h] [--version] [-v] [--username USERNAME]
                    [-f {gpx,tcx,original,json}] [-d DIRECTORY] [-s SUBDIR]
                    [-lp LOGPATH] [-u] [-ot] [--desc [DESC]] [-t TEMPLATE]
                    [-fp] [-sa START_ACTIVITY_NO] [-ex FILE]
+                   [-ss DIRECTORY]
 
 Garmin Connect Exporter
 
@@ -96,6 +97,8 @@ optional arguments:
   -ex FILE, --exclude FILE
                         JSON file with Array of activity IDs to exclude from download.
                         Format example: {"ids": ["6176888711"]}
+  -ss DIRECTORY, --session DIRECTORY
+                        enable loading and storing SSO information from/to given directory
 ```
 
 ### Examples

--- a/gcexport.py
+++ b/gcexport.py
@@ -112,6 +112,7 @@ URL_GC_GPX_ACTIVITY = f'{GARMIN_BASE_URL}/download-service/export/gpx/activity/'
 URL_GC_TCX_ACTIVITY = f'{GARMIN_BASE_URL}/download-service/export/tcx/activity/'
 URL_GC_ORIGINAL_ACTIVITY = f'{GARMIN_BASE_URL}/download-service/files/activity/'
 
+
 class GarminException(Exception):
     """Exception for problems with Garmin Connect (connection, data consistency etc)."""
 


### PR DESCRIPTION
Garth is able to load and save the SSO data to/from a directory. This speeds up access to Garmin Connect data. Additionally, it is particularly useful when 2FA is enabled in Garmin Connect. Otherwise one has to enter a security code every time you log in, which is very cumbersome when using gcexport in scripts.
Because the data is sensitive and not every user may want to store this data by default, this feature is only enabled if the user specifies the `-ss`/`--session` argument along with a directory where the SSO data is stored
