### PR TITLE
Add filtering by human-readable activity type

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ optional arguments:
                         JSON file with array of activity IDs to exclude from download.
                         Format example: {"ids": ["6176888711"]}
   -tf TYPE_FILTER, --type_filter TYPE_FILTER
-                        comma-separated list of activity type IDs to allow. Format example: 3,9
+                        comma-separated list of activity types to allow. Format example: 'walking,hiking'
   -ss DIRECTORY, --session DIRECTORY
                         enable loading and storing SSO information from/to given directory
 ```

--- a/gcexport.py
+++ b/gcexport.py
@@ -997,10 +997,12 @@ def annotate_activity_list(activities, start, exclude_list, type_filter):
             action = 's'
         elif str(activity['activityId']) in exclude_list:
             action = 'e'
-        elif type_filter is not None and activity['activityType']['typeId'] not in type_filter:
-            action = 'f'
         else:
-            action = 'd'
+            type = activity['activityType']
+            if type_filter is not None and str(type['typeId']) not in type_filter and type['typeKey'] not in type_filter:
+                action = 'f'
+            else:
+                action = 'd'
 
         action_list.append({"index": index, "action": action, "activity": activity})
 
@@ -1159,8 +1161,8 @@ def process_activity_item(item, number_of_items, device_dict, type_filter, activ
     # Action: Filtered out by typeId
     if action == 'f':
         # Display which entry we're skipping.
-        type_id = actvty['activityType']['typeId']
-        print(f"Filtering out due to type ID {type_id} not in {type_filter}: Garmin Connect activity ", end='')
+        type = actvty['activityType']
+        print(f"Filtering out due to type {type['typeKey']} (ID {type['typeId']}) not in {type_filter}: Garmin Connect activity ", end='')
         print(f"({current_index}/{number_of_items}) [{actvty['activityId']}]")
         return
 
@@ -1298,7 +1300,7 @@ def main(argv):
 
     activities = fetch_activity_list(args, total_to_download)
 
-    type_filter = list(map(int, args.type_filter.split(','))) if args.type_filter is not None else None
+    type_filter = args.type_filter.split(',') if args.type_filter is not None else None
 
     action_list = annotate_activity_list(activities, args.start_activity_no, exclude_list, type_filter)
 


### PR DESCRIPTION
Something that bothered me every time I downloaded a new batch of activities with this script is that it requires numeric type IDs that can be pretty hard to discover (basically same as #106) or remember.

This PR adds ability to filter out by human-readable activity type instead, so you can use `-tf walking,hiking` instead of `-tf 3,9`.

The documentation was switched to show just the human-readable filter as I think it will be preferable in vast majority of usecases, but the old ID-based filter is kept in code too for backward compatibility.