### PR TITLE
Add Dockerfile and usage examples to README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY . .
+RUN pip install --no-cache-dir -r requirements.txt
+
+ENTRYPOINT ["python3", "gcexport.py"]
+
+# Default command if no arguments are provided to `docker run`
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM python:3.13-slim
+FROM python:3.13-slim@sha256:f2fdaec50160418e0c2867ba3e254755edd067171725886d5d303fd7057bbf81
 
 WORKDIR /app
 
-COPY . .
+# Install deps first to improve caching.
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+COPY . .
 ENTRYPOINT ["python3", "gcexport.py"]
 
 # Default command if no arguments are provided to `docker run`

--- a/README.md
+++ b/README.md
@@ -34,7 +34,16 @@ If there is no GPS track data (e.g., due to an indoor treadmill workout), a data
 
 If you have many activities, you may find that this script crashes with an "Operation timed out" message. Just run the script again and it will pick up where it left off.
 
-## Installation
+## Running the script
+
+To run the script, you can either:
+
+- Run the script using the Docker CLI using the pre-built Docker image. See [Docker Usage](#docker-usage) for details.
+- Install the dependencies locally and run the script using the Python CLI. See [Local Installation](#local-installation) and [Usage](#usage) for details.
+
+## Local Installation
+
+If you are **not** using Docker, install the dependencies locally:
 
 - If you're comfortable using Git, just clone the repo from github
 - Otherwise get the latest `zip` (or `tar.gz`) from the [releases page](https://github.com/pe-st/garmin-connect-export/releases)
@@ -93,6 +102,84 @@ optional arguments:
                         comma-separated list of activity types to allow. Format example: 'walking,hiking'
   -ss DIRECTORY, --session DIRECTORY
                         enable loading and storing SSO information from/to given directory
+```
+
+### Docker Usage
+
+This section contains some tips and tricks to run the script using Docker. See the [Usage](#usage) section above for general script usage.
+
+#### Create working directory
+
+Create a directory where you want to store the garmin export data and session data:
+
+```shell
+mkdir -p ~/Documents/garmin_export
+cd ~/Documents/garmin_export
+```
+
+#### Set environment variables
+
+Export your username and password as environment variables:
+
+```shell
+export GARMIN_USERNAME=abc
+export GARMIN_PASSWORD=xyz
+```
+
+#### Run the docker container
+
+When running the docker container, make sure to:
+
+1. Override the `--directory` and `--session` command line arguments with static directories in the container.
+2. Mount the static `export_data` and `session_data` directories in the container to your local directories.
+
+This results in garmin export data being outputted to the local `./my_garmin_data` directory.
+
+```shell
+docker run -it --rm \
+  -v "$(pwd)/my_garmin_data:/export_data" \
+  -v "$(pwd)/my_garmin_session:/session_data" \
+  garmin-connect-exporter \
+  --directory /export_data \
+  --subdir '{YYYY}/{MM}/' \
+  --logpath /export_data/logs \
+  --session /session_data \
+  --username ${GARMIN_USERNAME} \
+  --password ${GARMIN_PASSWORD}
+```
+
+Optionally, follow the same process for the `--template` argument:
+
+```shell
+
+docker run -it --rm \
+  -v "$(pwd)/my_garmin_template:/template_data" \
+  ... \
+  garmin-connect-exporter \
+  --template /template_data/my_template.properties \
+  ...
+```
+
+#### Output directories
+
+After running the script, you should see the following directories in your working directory (e.g. `~/Documents/garmin_export`):
+
+```text
+.
+├── my_garmin_data
+│   ├── 2025
+│   │   └── 05
+│   │       └── activity_19000000000.gpx
+│   ├── activities-1-1.json
+│   ├── activities.csv
+│   ├── device_120000.json
+│   ├── downloaded_ids.json
+│   ├── logs
+│   │   └── gcexport.log
+│   └── userstats.json
+└── my_garmin_session
+    ├── oauth1_token.json
+    └── oauth2_token.json
 ```
 
 ### Authentication


### PR DESCRIPTION
## Description

- Adds a Dockerfile to build the docker image
- Adds docker usage instructions to README.md

## Testing Done

Image builds successfully:
```
docker build -t garmin-connect-exporter .

[+] Building 7.8s (9/9) FINISHED                                                                                                                 docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 291B                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                  0.0s
=> [internal] load metadata for docker.io/library/python:3.11-slim                                                                                              1.3s
 => [1/4] FROM docker.io/library/python:3.11-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c                                        1.1s
 => => resolve docker.io/library/python:3.11-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c                                        0.0s
 => => sha256:b7c08fd34265f32576e55c9dddd9f235b8b7f60fd6444cf617d7b15d08b2273a 16.13MB / 16.13MB                                                                 0.6s
 => => sha256:92fbff4eeba45536c25e921782477b78ed2f0017f075066d2da8420ca9df42a3 248B / 248B                                                                       0.1s
 => => sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c 9.13kB / 9.13kB                                                                   0.0s
 => => sha256:ea2bf1a9fc56bd9904263534a315b2493a81724fe20fe81a695012d45bc3ab43 1.75kB / 1.75kB                                                                   0.0s
 => => sha256:277bcd31f17f0de7684e81ae149309e939bc6169931ee771a716b839325a393c 5.39kB / 5.39kB                                                                   0.0s
 => => extracting sha256:b7c08fd34265f32576e55c9dddd9f235b8b7f60fd6444cf617d7b15d08b2273a                                                                        0.4s
 => => extracting sha256:92fbff4eeba45536c25e921782477b78ed2f0017f075066d2da8420ca9df42a3                                                                        0.0s
 => [internal] load build context                                                                                                                                0.0s
 => => transferring context: 1.15MB                                                                                                                              0.0s
 => [2/4] WORKDIR /app                                                                                                                                           0.1s
 => [3/4] COPY . .                                                                                                                                               0.0s
 => [4/4] RUN pip install --no-cache-dir -r requirements.txt                                                                                                     3.4s
 => exporting to image                                                                                                                                           0.1s
 => => exporting layers                                                                                                                                          0.1s
 => => writing image sha256:80eac3fc46098e6dd5bff1be0434896cd99012a7e317a92c61665e3d7a088892                                                                     0.0s
 => => naming to docker.io/library/garmin-connect-exporter                                                                                                       0.0s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/ukgos53gfoqzsf63w4s9ln4rv

What's Next?
  1. Sign in to your Docker account → docker login
  2. View a summary of image vulnerabilities and recommendations → docker scout quickview
```

Image runs successfully:
```
docker run -it --rm \
  -v "$(pwd)/my_garmin_data:/export_data" \
  -v "$(pwd)/my_garmin_session:/session_data" \
  garmin-connect-exporter \
  --directory /export_data \
  --subdir '{YYYY}/{MM}/' \
  --logpath /export_data/logs \
  --session /session_data \
  --username ${GARMIN_USERNAME} \
  --password ${GARMIN_PASSWORD}
Welcome to Garmin Connect Exporter!
[WARNING] Output directory /export_data already exists. Will skip already-downloaded files and append to the CSV file.
Authenticating... Done.
Getting display name... Done. displayName=123-REDACTED
Fetching user stats... Done.
Querying list of activities 1..1... Done.
Downloading: Garmin Connect activity (1/1) [19REDACTED] City Running
	2025-05-31TREDACTED, REDACTED, 2.000 km
Done!
```

Output looks good in my working directory:
```
.
├── my_garmin_data
│   ├── 2025
│   │   └── 05
│   │       └── activity_19000000000.gpx
│   ├── activities-1-1.json
│   ├── activities.csv
│   ├── device_120000.json
│   ├── downloaded_ids.json
│   ├── logs
│   │   └── gcexport.log
│   └── userstats.json
└── my_garmin_session
    ├── oauth1_token.json
    └── oauth2_token.json
```

## Follow ups

- [ ] @pe-st to create github action to build docker image
- [ ] @nareddyt to replace the `garmin-connect-exporter` in the docker usage instructions with the real image.

Closes https://github.com/pe-st/garmin-connect-export/issues/120